### PR TITLE
refactor: replace Jersey REST Client with java.net.http.HttpClient

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ on:
       - "pom.xml"
     branches:
       - master
-      - 'refactor/**'
-      - 'fix/**'
-      - 'feature/**'
-      - 'chore/**'
   pull_request:
     types:
       - opened

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,7 @@ jobs:
           cache: "maven"
       - name: Build with Maven (skip tests)
         run: ./mvnw -B install -DskipTests --file pom.xml
+
+  integration-tests:
+    needs: build
+    uses: ./.github/workflows/integration-tests.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
       - "pom.xml"
     branches:
       - master
+      - 'refactor/**'
+      - 'fix/**'
+      - 'feature/**'
+      - 'chore/**'
   pull_request:
     types:
       - opened
@@ -26,7 +30,3 @@ jobs:
           cache: "maven"
       - name: Build with Maven (skip tests)
         run: ./mvnw -B install -DskipTests --file pom.xml
-
-  integration-tests:
-    needs: build
-    uses: ./.github/workflows/integration-tests.yml

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,14 +1,10 @@
 name: Integration Tests
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   gf7-managed:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +18,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests --file pom.xml
 
   gf7-remote:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:
@@ -49,7 +44,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-remote --file pom.xml
 
   gf8-managed:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +57,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-managed,glassfish8 --file pom.xml
 
   gf8-remote:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,20 @@
 name: Integration Tests
 
 on:
-  workflow_call:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+    branches:
+      - master
+      - 'refactor/**'
+      - 'fix/**'
+      - 'feature/**'
+      - 'chore/**'
 
 jobs:
   gf7-managed:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +28,7 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests --file pom.xml
 
   gf7-remote:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:
@@ -44,6 +55,7 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-remote --file pom.xml
 
   gf8-managed:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +69,7 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-managed,glassfish8 --file pom.xml
 
   gf8-remote:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,20 +1,20 @@
 name: Integration Tests
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  push:
+    paths:
+      - "glassfish-*/**"
+      - "pom.xml"
     branches:
       - master
-      - 'refactor/**'
-      - 'fix/**'
-      - 'feature/**'
-      - 'chore/**'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   gf7-managed:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests --file pom.xml
 
   gf7-remote:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:
@@ -55,7 +54,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-remote --file pom.xml
 
   gf8-managed:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +67,6 @@ jobs:
         run: ./mvnw -B verify -pl integration-tests -Pglassfish-managed,glassfish8 --file pom.xml
 
   gf8-remote:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     services:
       glassfish:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4/apache-maven-4.0.0-rc-4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-6/apache-maven-4.0.0-rc-6-bin.zip

--- a/glassfish-common/pom.xml
+++ b/glassfish-common/pom.xml
@@ -18,18 +18,5 @@
       <artifactId>arquillian-container-test-spi</artifactId>
     </dependency>
 
-    <!-- Jersey -->
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-multipart</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishConfiguration.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishConfiguration.java
@@ -16,10 +16,11 @@
  */
 package org.jboss.arquillian.container.glassfish;
 
+import java.util.Objects;
+
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClient;
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
-import org.jboss.arquillian.container.spi.client.deployment.Validate;
 
 /**
  * The common set of properties for a GLassFish container.
@@ -251,8 +252,8 @@ public class CommonGlassFishConfiguration implements ContainerConfiguration {
      */
     public void validate() throws ConfigurationException {
         if (isAuthorisation()) {
-            Validate.notNull(getAdminUser(), "adminUser must be specified to use authorisation");
-            Validate.notNull(getAdminPassword(), "adminPassword must be specified to use authorisation");
+            Objects.requireNonNull(getAdminUser(), "adminUser must be specified to use authorisation");
+            Objects.requireNonNull(getAdminPassword(), "adminPassword must be specified to use authorisation");
         }
     }
 }

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishManager.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishManager.java
@@ -16,11 +16,10 @@
  */
 package org.jboss.arquillian.container.glassfish;
 
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClient;
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClientException;
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClientService;
+import org.jboss.arquillian.container.glassfish.clientutils.MultipartBody;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
@@ -28,7 +27,6 @@ import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaD
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 
-import jakarta.ws.rs.core.MediaType;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -84,8 +82,8 @@ public class CommonGlassFishManager<C extends CommonGlassFishConfiguration> {
             InputStream deployment = archive.as(ZipExporter.class).exportAsInputStream();
 
             // Build up the POST form to send to Glassfish
-            final FormDataMultiPart form = new FormDataMultiPart();
-            form.bodyPart(new StreamDataBodyPart("id", deployment, archiveName));
+            final MultipartBody form = new MultipartBody();
+            form.addFilePart("id", archiveName, deployment);
 
             deploymentName = createDeploymentName(archiveName);
             addDeployFormFields(deploymentName, form);
@@ -108,9 +106,9 @@ public class CommonGlassFishManager<C extends CommonGlassFishConfiguration> {
             deploymentName = createDeploymentName(archive.getName());
             try {
                 // Build up the POST form to send to Glassfish
-                final FormDataMultiPart form = new FormDataMultiPart();
-                form.field("target", this.configuration.getTarget(), MediaType.TEXT_PLAIN_TYPE);
-                form.field("operation", DELETE_OPERATION, MediaType.TEXT_PLAIN_TYPE);
+                final MultipartBody form = new MultipartBody();
+                form.addField("target", this.configuration.getTarget(), "text/plain");
+                form.addField("operation", DELETE_OPERATION, "text/plain");
                 glassFishClient.doUndeploy(this.deploymentName, form);
             } catch (GlassFishClientException e) {
                 throw new DeploymentException("Could not undeploy " + archive.getName(), e);
@@ -133,27 +131,27 @@ public class CommonGlassFishManager<C extends CommonGlassFishConfiguration> {
         return correctedName;
     }
 
-    private void addDeployFormFields(String name, FormDataMultiPart deployform) {
+    private void addDeployFormFields(String name, MultipartBody deployform) {
 
         // add the name field, the name is the archive filename without extension
-        deployform.field("name", name, MediaType.TEXT_PLAIN_TYPE);
+        deployform.addField("name", name, "text/plain");
 
         // add the target field (the default is "server" - Admin Server)
-        deployform.field("target", this.configuration.getTarget(), MediaType.TEXT_PLAIN_TYPE);
+        deployform.addField("target", this.configuration.getTarget(), "text/plain");
 
         // add the libraries field (optional)
         if (this.configuration.getLibraries() != null) {
-            deployform.field("libraries", this.configuration.getLibraries(), MediaType.TEXT_PLAIN_TYPE);
+            deployform.addField("libraries", this.configuration.getLibraries(), "text/plain");
         }
 
         // add the properties field (optional)
         if (this.configuration.getProperties() != null) {
-            deployform.field("properties", this.configuration.getProperties(), MediaType.TEXT_PLAIN_TYPE);
+            deployform.addField("properties", this.configuration.getProperties(), "text/plain");
         }
 
         // add the type field (optional, the only valid value is "osgi", other values are ommited)
         if (this.configuration.getType() != null && "osgi".equals(this.configuration.getType())) {
-            deployform.field("type", this.configuration.getType(), MediaType.TEXT_PLAIN_TYPE);
+            deployform.addField("type", this.configuration.getType(), "text/plain");
         }
     }
 }

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClient.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClient.java
@@ -20,7 +20,6 @@
  */
 package org.jboss.arquillian.container.glassfish.clientutils;
 
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
 
@@ -31,42 +30,34 @@ public interface GlassFishClient {
     /**
      * Admin Server key for the REST request.
      */
-    public static final String ADMINSERVER = "server";
+    String ADMINSERVER = "server";
 
     /**
      * Start-up the server
-     * <p>
-     * -   Get the node addresses list associated with the target
-     * -   Check the status of the target server instance
-     * -   In case of cluster tries to fund an instance which has
-     * RUNNING status
-     *
-     * @return none
      */
-    public void startUp();
+    void startUp();
 
     /**
      * Do deploy an application defined by a multipart form's data
-     * to the target server or cluster of GlassFish 3.1
+     * to the target server or cluster of GlassFish.
      *
-     * @param name
-     *     - name of the appliacation
-     *     form		- a form of MediaType.MULTIPART_FORM_DATA_TYPE
-     *
+     * @param name - name of the application
+     * @param form - multipart form containing the deployment archive and fields
      * @return subComponents - a map of SubComponents of the application
      */
-    public HTTPContext doDeploy(String name, FormDataMultiPart form) throws DeploymentException;
+    HTTPContext doDeploy(String name, MultipartBody form) throws DeploymentException;
 
     /**
      * Do undeploy the application
      *
      * @param name - application name
+     * @param form - multipart form containing undeploy fields
      * @return responseMap
      */
-    public Map<String, Object> doUndeploy(String name, FormDataMultiPart form);
+    Map<String, Object> doUndeploy(String name, MultipartBody form);
 
     /**
      * Verify whether the Domain Administration Server is running.
      */
-    public boolean isDASRunning();
+    boolean isDASRunning();
 }

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientService.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientService.java
@@ -20,19 +20,14 @@
  */
 package org.jboss.arquillian.container.glassfish.clientutils;
 
-import static jakarta.ws.rs.core.HttpHeaders.USER_AGENT;
-
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.jboss.arquillian.container.glassfish.CommonGlassFishConfiguration;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
@@ -222,19 +217,14 @@ public class GlassFishClientService implements GlassFishClient {
      * @return subComponents - a map of SubComponents of the application
      */
     @Override
-    public HTTPContext doDeploy(String name, FormDataMultiPart form) {
+    public HTTPContext doDeploy(String name, MultipartBody form) {
         // Deploy the application on the GlassFish server
         getClientUtil().POSTMultiPartRequest(APPLICATION, form);
 
         // Fetch the list of SubComponents of the application
-        WebTarget listSubCompsGET = getClientUtil().prepareGET();
-        Response response = listSubCompsGET.path(APPLICATION_RESOURCE + "/list-sub-components")
-            .resolveTemplate("name", name)
-            .request(MediaType.APPLICATION_XML_TYPE)
-            .header(USER_AGENT, USER_AGENT_VALUE)
-            .get();
-
-        var subComponentsResponse = getClientUtil().getResponseMap(response);
+        var subComponentsResponse = getClientUtil().GETRequest(
+            APPLICATION_RESOURCE + "/list-sub-components",
+            Map.of("name", name), null);
         var subComponents = (Map<String, String>) subComponentsResponse.get("properties");
 
         // Build up the HTTPContext object using the nodeAddress information
@@ -270,7 +260,7 @@ public class GlassFishClientService implements GlassFishClient {
      * @return resultMap
      */
     @Override
-    public Map<String, Object> doUndeploy(String name, FormDataMultiPart form) {
+    public Map<String, Object> doUndeploy(String name, MultipartBody form) {
         String path = APPLICATION_RESOURCE.replace("{name}", name);
         return getClientUtil().POSTMultiPartRequest(path, form);
     }
@@ -377,18 +367,14 @@ public class GlassFishClientService implements GlassFishClient {
     private void resolveWebModuleSubComponents(String name, String module, String context,
         HTTPContext httpContext) {
         // Fetch the list of SubComponents of the application
-        WebTarget listAppSubCompGET = getClientUtil().prepareGET();
-        Response response = listAppSubCompGET.path(
-                "/applications/application/{application}/list-sub-components")
-            .resolveTemplate("application", name)
-            .queryParam("appname", name)
-            .queryParam("id", module)
-            .queryParam("type", "servlets")
-            .request(MediaType.APPLICATION_XML_TYPE)
-            .header(USER_AGENT, USER_AGENT_VALUE)
-            .get();
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("appname", name);
+        queryParams.put("id", module);
+        queryParams.put("type", "servlets");
 
-        Map<String, Object> subComponentsResponce = getClientUtil().getResponseMap(response);
+        Map<String, Object> subComponentsResponce = getClientUtil().GETRequest(
+            "/applications/application/{application}/list-sub-components",
+            Map.of("application", name), queryParams);
         Map<String, String> subComponents = (Map<String, String>) subComponentsResponce.get(
             "properties");
 
@@ -549,13 +535,8 @@ public class GlassFishClientService implements GlassFishClient {
      */
     private List<String> getVirtualServers(Map<String, String> attributes) {
         String config = attributes.get("configRef").replace("{target}", attributes.get("name"));
-        WebTarget vsGET = getClientUtil().prepareGET();
-        Response response = vsGET.path(VIRTUAL_SERVERS)
-            .resolveTemplate("config", config)
-            .request(MediaType.APPLICATION_XML_TYPE)
-            .header(USER_AGENT, USER_AGENT_VALUE)
-            .get();
-        Map<String, Object> virtualServersResponse = getClientUtil().getResponseMap(response);
+        Map<String, Object> virtualServersResponse = getClientUtil().GETRequest(
+            VIRTUAL_SERVERS, Map.of("config", config), null);
         List<Map<String, Object>> virtualServers = (List<Map<String, Object>>) virtualServersResponse.get("children");
         List<String> virtualServerNames = new ArrayList<>();
         for (Map<String, Object> virtualServer : virtualServers) {

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientService.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientService.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -151,19 +150,18 @@ public class GlassFishClientService implements GlassFishClient {
                 "extraProperties");
             if (extraProperties != null) {
                 Object versionNumberObj = extraProperties.get("version-number");
-                if (versionNumberObj instanceof String) {
-                    String version = (String) versionNumberObj;
-                    StringTokenizer tokenizer = new StringTokenizer(version, ".");
-                    if (tokenizer.hasMoreElements()) {
+                if (versionNumberObj instanceof String version) {
+                    String[] parts = version.split("\\.");
+                    if (parts.length > 0) {
                         try {
-                            majorVersion = Integer.parseInt(tokenizer.nextToken());
+                            majorVersion = Integer.parseInt(parts[0]);
                         } catch (NumberFormatException ignore) {
                             log.info("Exception getting major version for: " + version);
                         }
                     }
-                    if (tokenizer.hasMoreElements()) {
+                    if (parts.length > 1) {
                         try {
-                            minorVersion = Integer.parseInt(tokenizer.nextToken());
+                            minorVersion = Integer.parseInt(parts[1]);
                         } catch (NumberFormatException ignore) {
                             log.info("Exception getting minor version for: " + version);
                         }
@@ -557,10 +555,10 @@ public class GlassFishClientService implements GlassFishClient {
             .request(MediaType.APPLICATION_XML_TYPE)
             .header(USER_AGENT, USER_AGENT_VALUE)
             .get();
-        Map virtualServersResponse = getClientUtil().getResponseMap(response);
-        List<Map> virtualServers = (List<Map>) virtualServersResponse.get("children");
-        List<String> virtualServerNames = new ArrayList<String>();
-        for (Map virtualServer : virtualServers) {
+        Map<String, Object> virtualServersResponse = getClientUtil().getResponseMap(response);
+        List<Map<String, Object>> virtualServers = (List<Map<String, Object>>) virtualServersResponse.get("children");
+        List<String> virtualServerNames = new ArrayList<>();
+        for (Map<String, Object> virtualServer : virtualServers) {
             String virtualServerName = (String) virtualServer.get("message");
             if (!virtualServerName.equals("__asadmin")) {
                 virtualServerNames.add(virtualServerName);
@@ -871,7 +869,7 @@ public class GlassFishClientService implements GlassFishClient {
             String httpPortNum = getActiveHttpPort(clusterAttributes, networkListeners, false);
             String httpsPortNum = getActiveHttpPort(clusterAttributes, networkListeners, true);
 
-            for (Map.Entry serverInstance : serverInstances.entrySet()) {
+            for (Map.Entry<String, String> serverInstance : serverInstances.entrySet()) {
                 String serverName = serverInstance.getKey().toString();
 
                 serverAttributes = getServerAttributes(serverName);

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientUtil.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientUtil.java
@@ -81,7 +81,7 @@ public class GlassFishClientUtil {
 
     public Map<String, String> getAttributes(String additionalResourceUrl) {
         Map<String, Object> responseMap = GETRequest(additionalResourceUrl);
-        Map<String, String> attributes = new HashMap<String, String>();
+        Map<String, String> attributes = new HashMap<>();
 
         Map<String, Map<String, String>> resultExtraProperties = (Map<String, Map<String, String>>) responseMap.get("extraProperties");
         if (resultExtraProperties != null) {
@@ -93,7 +93,7 @@ public class GlassFishClientUtil {
 
     public Map<String, String> getChildResources(String additionalResourceUrl) throws GlassFishClientException {
         Map<String, Object> responseMap = GETRequest(additionalResourceUrl);
-        Map<String, String> childResources = new HashMap<String, String>();
+        Map<String, String> childResources = new HashMap<>();
 
         Map<String, Object> resultExtraProperties = (Map<String, Object>) responseMap.get("extraProperties");
         if (resultExtraProperties != null) {
@@ -144,7 +144,7 @@ public class GlassFishClientUtil {
 
     public List<Map<String,Object>> getInstancesList(String additionalResourceUrl) throws GlassFishClientException {
         Map<String, Object> responseMap = GETRequest(additionalResourceUrl);
-        List<Map<String,Object>> instancesList = new ArrayList<Map<String,Object>>();
+        List<Map<String,Object>> instancesList = new ArrayList<>();
 
         Map<String, Object> resultExtraProperties = (Map<String, Object>) responseMap.get("extraProperties");
         if (resultExtraProperties != null) {
@@ -281,7 +281,7 @@ public class GlassFishClientUtil {
     private Map<String, Object> resolveXmlMap(XMLStreamReader stream) throws XMLStreamException {
 
         boolean endMapFlag = false;
-        Map<String, Object> entry = new HashMap<String, Object>();
+        Map<String, Object> entry = new HashMap<>();
         String key = null;
         String elementName = null;
 
@@ -298,10 +298,10 @@ public class GlassFishClientUtil {
                         key = null;
                     }
                 } else if ("map".equals(stream.getLocalName())) {
-                    Map value = resolveXmlMap(stream);
+                    Map<String, Object> value = resolveXmlMap(stream);
                     entry.put(key, value);
                 } else if ("list".equals(stream.getLocalName())) {
-                    List value = resolveXmlList(stream);
+                    List<Object> value = resolveXmlList(stream);
                     entry.put(key, value);
                 } else {
                     elementName = stream.getLocalName();
@@ -332,10 +332,10 @@ public class GlassFishClientUtil {
         return entry;
     }
 
-    private List resolveXmlList(XMLStreamReader stream) throws XMLStreamException {
+    private List<Object> resolveXmlList(XMLStreamReader stream) throws XMLStreamException {
 
         boolean endListFlag = false;
-        List list = new ArrayList();
+        List<Object> list = new ArrayList<>();
         String elementName = null;
 
         while (!endListFlag) {

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientUtil.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/GlassFishClientUtil.java
@@ -20,21 +20,8 @@
  */
 package org.jboss.arquillian.container.glassfish.clientutils;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Response;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
-import org.glassfish.jersey.logging.LoggingFeature;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.jboss.arquillian.container.glassfish.CommonGlassFishConfiguration;
 
-import jakarta.ws.rs.core.MediaType;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -42,15 +29,20 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static jakarta.ws.rs.core.HttpHeaders.USER_AGENT;
 
 public class GlassFishClientUtil {
 
@@ -64,19 +56,46 @@ public class GlassFishClientUtil {
      */
     public static final String WARNING = "WARNING";
 
+    private static final String CSRF_HEADER = "X-Requested-By";
+    private static final String CSRF_VALUE = "GlassFish REST Client";
+    private static final String USER_AGENT_HEADER = "User-Agent";
+
     private CommonGlassFishConfiguration configuration;
 
     private String adminBaseUrl;
+
+    private HttpClient httpClient;
 
     private static final Logger log = Logger.getLogger(GlassFishClientUtil.class.getName());
 
     public GlassFishClientUtil(CommonGlassFishConfiguration configuration, String adminBaseUrl) {
         this.configuration = configuration;
         this.adminBaseUrl = adminBaseUrl;
+        HttpClient.Builder builder = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30));
+        if (configuration.isAuthorisation()) {
+            builder.authenticator(new GlassFishAuthenticator(
+                configuration.getAdminUser(), configuration.getAdminPassword()));
+        }
+        this.httpClient = builder.build();
     }
 
     public CommonGlassFishConfiguration getConfiguration() {
         return configuration;
+    }
+
+    /**
+     * Returns the pre-configured {@link HttpClient} for callers that need to build custom requests.
+     */
+    public HttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    /**
+     * Returns the admin base URL for callers that need to build custom request URIs.
+     */
+    public String getAdminBaseUrl() {
+        return adminBaseUrl;
     }
 
     public Map<String, String> getAttributes(String additionalResourceUrl) {
@@ -104,104 +123,105 @@ public class GlassFishClientUtil {
     }
 
     /**
-     * Create a WebTarget for accessing a subpath under the admin endpoint that has authorization, logging
-     * and CSRF setup.
-     *
-     * @return WebTarget for admin base endpoint
-     */
-    public WebTarget prepareGET() {
-        ClientBuilder builder = ClientBuilder.newBuilder();
-        ClientConfig jerseyConfig = new ClientConfig();
-        if (configuration.isAuthorisation()) {
-            jerseyConfig.register(HttpAuthenticationFeature.basic(configuration.getAdminUser(), configuration.getAdminPassword()));
-        }
-        if (configuration.isDebugRequests()) {
-            jerseyConfig.register(new LoggingFeature(Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME),
-                                                     Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 10000));
-        }
-        builder.withConfig(jerseyConfig);
-        builder.register(new CsrfProtectionFilter());
-        Client client = builder.build();
-        return client.target(this.adminBaseUrl);
-    }
-
-    /**
-     * Invoke a GET request against the adminSubPath
+     * Invoke a GET request against the adminSubPath.
      * @param adminSubPath - subpath of the admin command
      * @return map of the parsed XML response
      */
     public Map<String, Object> GETRequest(String adminSubPath) {
         try {
-            Invocation.Builder getBuilder = prepareClient(adminSubPath, false);
-            Response response = getBuilder.buildGet().invoke();
-            Map<String, Object> responseMap = getResponseMap(response);
-
-            return responseMap;
-        } catch (Exception e) {
-            throw new GlassFishClientException(e);
-        }
-    }
-
-    public List<Map<String,Object>> getInstancesList(String additionalResourceUrl) throws GlassFishClientException {
-        Map<String, Object> responseMap = GETRequest(additionalResourceUrl);
-        List<Map<String,Object>> instancesList = new ArrayList<>();
-
-        Map<String, Object> resultExtraProperties = (Map<String, Object>) responseMap.get("extraProperties");
-        if (resultExtraProperties != null) {
-            instancesList = (List<Map<String,Object>>) resultExtraProperties.get("instanceList");
-        }
-
-        return instancesList;
-    }
-
-    public Map<String, Object> POSTMultiPartRequest(String additionalResourceUrl, FormDataMultiPart form) {
-        try {
-            Response response = prepareClient(additionalResourceUrl, true)
-                .accept(MediaType.MULTIPART_FORM_DATA_TYPE)
-                .buildPost(Entity.entity(form, MediaType.MULTIPART_FORM_DATA))
-                .invoke();
-            Map<String, Object> responseMap = getResponseMap(response);
-
-        return responseMap;
+            HttpRequest request = newGetBuilder()
+                .uri(URI.create(adminBaseUrl + adminSubPath))
+                .GET()
+                .build();
+            HttpResponse<String> response = sendRequest(request);
+            return getResponseMap(response);
         } catch (Exception e) {
             throw new GlassFishClientException(e);
         }
     }
 
     /**
-     * Basic REST call preparation, with the additional resource url appended
+     * Invoke a GET request with path template resolution and query parameters.
      *
-     * @param additionalResourceUrl
-     *     url portion past the base to use
-     *
-     * @return the resource builder to execute
+     * @param pathTemplate a URI path template with {var} placeholders
+     * @param templateVars variables to resolve in the path template
+     * @param queryParams  query parameters to append (can be null or empty)
+     * @return map of the parsed XML response
      */
-    private Invocation.Builder prepareClient(String additionalResourceUrl, boolean multiPart) {
-        ClientBuilder builder = ClientBuilder.newBuilder();
-        ClientConfig jerseyConfig = new ClientConfig();
-        if (configuration.isAuthorisation()) {
-            jerseyConfig.register(HttpAuthenticationFeature.basic(configuration.getAdminUser(), configuration.getAdminPassword()));
+    public Map<String, Object> GETRequest(String pathTemplate, Map<String, String> templateVars,
+                                           Map<String, String> queryParams) {
+        String resolvedPath = resolveTemplates(pathTemplate, templateVars);
+        String fullPath = resolvedPath;
+        if (queryParams != null && !queryParams.isEmpty()) {
+            fullPath += "?" + buildQueryString(queryParams);
         }
-        if (multiPart) {
-            jerseyConfig.register(MultiPartFeature.class);
-        }
-        if (configuration.isDebugRequests()) {
-            jerseyConfig.register(new LoggingFeature(Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME),
-                                                     Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 10000));
-        }
-        builder.withConfig(jerseyConfig);
-        builder.register(new CsrfProtectionFilter());
-        Client client = builder.build();
-        return client.target(this.adminBaseUrl)
-            .path(additionalResourceUrl)
-            .request(MediaType.APPLICATION_XML_TYPE)
-            .header(USER_AGENT, GlassFishClientService.USER_AGENT_VALUE);
+        return GETRequest(fullPath);
     }
 
-    Map<String, Object> getResponseMap(Response response) throws GlassFishClientException {
+    public List<Map<String, Object>> getInstancesList(String additionalResourceUrl) throws GlassFishClientException {
+        Map<String, Object> responseMap = GETRequest(additionalResourceUrl);
+        List<Map<String, Object>> instancesList = new ArrayList<>();
+
+        Map<String, Object> resultExtraProperties = (Map<String, Object>) responseMap.get("extraProperties");
+        if (resultExtraProperties != null) {
+            instancesList = (List<Map<String, Object>>) resultExtraProperties.get("instanceList");
+        }
+
+        return instancesList;
+    }
+
+    public Map<String, Object> POSTMultiPartRequest(String additionalResourceUrl, MultipartBody form) {
+        try {
+            HttpRequest request = newPostBuilder()
+                .uri(URI.create(adminBaseUrl + additionalResourceUrl))
+                .header("Content-Type", form.getContentType())
+                .POST(form.toBodyPublisher())
+                .build();
+            HttpResponse<String> response = sendRequest(request);
+            return getResponseMap(response);
+        } catch (Exception e) {
+            throw new GlassFishClientException(e);
+        }
+    }
+
+    /**
+     * Build a {@link HttpRequest.Builder} pre-configured with common headers for GET requests.
+     */
+    private HttpRequest.Builder newGetBuilder() {
+        return HttpRequest.newBuilder()
+            .header("Accept", "application/xml")
+            .header(CSRF_HEADER, CSRF_VALUE)
+            .header(USER_AGENT_HEADER, GlassFishClientService.USER_AGENT_VALUE);
+    }
+
+    /**
+     * Build a {@link HttpRequest.Builder} pre-configured with common headers for POST requests.
+     */
+    private HttpRequest.Builder newPostBuilder() {
+        return HttpRequest.newBuilder()
+            .header("Accept", "application/xml")
+            .header(CSRF_HEADER, CSRF_VALUE)
+            .header(USER_AGENT_HEADER, GlassFishClientService.USER_AGENT_VALUE);
+    }
+
+    private HttpResponse<String> sendRequest(HttpRequest request) throws IOException, InterruptedException {
+        if (configuration.isDebugRequests()) {
+            log.info("HTTP " + request.method() + " " + request.uri());
+            request.headers().map().forEach((name, values) ->
+                log.info("  " + name + ": " + String.join(", ", values)));
+        }
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (configuration.isDebugRequests()) {
+            log.info("HTTP response status: " + response.statusCode());
+            log.info("HTTP response body: " + response.body());
+        }
+        return response;
+    }
+
+    Map<String, Object> getResponseMap(HttpResponse<String> response) throws GlassFishClientException {
         Map<String, Object> responseMap = new HashMap<>();
         String message = "";
-        final String xmlDoc = response.readEntity(String.class);
+        final String xmlDoc = response.body();
 
         // Marshalling the XML format response to a java Map
         if (xmlDoc != null && !xmlDoc.isEmpty()) {
@@ -211,9 +231,9 @@ public class GlassFishClientUtil {
                 + ", message: " + responseMap.get("message");
         }
 
-        Response.StatusType status = response.getStatusInfo();
-        if (status.getFamily() == Response.Status.Family.SUCCESSFUL) {
-            // O.K. the jersey call was successful, what about the GlassFish server response?
+        int statusCode = response.statusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            // O.K. — the HTTP call was successful, what about the GlassFish server response?
             if (responseMap.get("exit_code") == null) {
                 throw new GlassFishClientException(message);
             } else if (WARNING.equals(responseMap.get("exit_code"))) {
@@ -223,12 +243,12 @@ public class GlassFishClientUtil {
                 // Response is not a warning nor success - it's surely a failure.
                 throw new GlassFishClientException(message);
             }
-        } else if (status.getReasonPhrase().contains("Not Found")) {
+        } else if (statusCode == 404) {
             // the REST resource can not be found (for optional resources it can be O.K.)
-            message += " [status: " + status.getFamily() + " reason: " + status.getReasonPhrase() + "]";
+            message += " [status: " + statusCode + "]";
             log.warning(message);
         } else {
-            message += " [status: " + status.getFamily() + " reason: " + status.getReasonPhrase() + "]";
+            message += " [status: " + statusCode + "]";
             log.severe(message);
             throw new GlassFishClientException(message);
         }
@@ -237,10 +257,9 @@ public class GlassFishClientUtil {
     }
 
     /**
-     * Marshalling a Glassfish Mng API response XML document to a java Map object
+     * Marshalling a Glassfish Mng API response XML document to a java Map object.
      *
      * @param document XML
-     *
      * @return map containing the XML doc representation in java map format
      */
     public Map<String, Object> xmlToMap(String document) {
@@ -371,5 +390,54 @@ public class GlassFishClientUtil {
             } // end if
         } // end while
         return list;
+    }
+
+    /**
+     * Resolve a URI path template with {var} placeholders.
+     */
+    static String resolveTemplates(String pathTemplate, Map<String, String> templateVars) {
+        String result = pathTemplate;
+        if (templateVars != null) {
+            for (var entry : templateVars.entrySet()) {
+                result = result.replace("{" + entry.getKey() + "}", entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Build a URL-encoded query string from a map of parameters.
+     */
+    static String buildQueryString(Map<String, String> queryParams) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (var entry : queryParams.entrySet()) {
+            if (!first) {
+                sb.append("&");
+            }
+            sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8));
+            sb.append("=");
+            sb.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+            first = false;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Simple HTTP Basic authenticator for GlassFish admin API.
+     */
+    private static class GlassFishAuthenticator extends java.net.Authenticator {
+        private final String user;
+        private final String password;
+
+        GlassFishAuthenticator(String user, String password) {
+            this.user = user;
+            this.password = password;
+        }
+
+        @Override
+        protected java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(user, password.toCharArray());
+        }
     }
 }

--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/MultipartBody.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/clientutils/MultipartBody.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.glassfish.clientutils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lightweight multipart/form-data body builder for {@link java.net.http.HttpClient}.
+ * Replaces Jersey's {@code FormDataMultiPart} / {@code StreamDataBodyPart}.
+ */
+public class MultipartBody {
+
+    private static final String CRLF = "\r\n";
+    private static final String TWO_HYPHENS = "--";
+
+    private final String boundary;
+    private final List<TextPart> textParts = new ArrayList<>();
+    private FilePart filePart;
+
+    public MultipartBody() {
+        this.boundary = "Boundary-" + System.currentTimeMillis();
+    }
+
+    /**
+     * Add a text field to the multipart form.
+     */
+    public void addField(String name, String value, String contentType) {
+        textParts.add(new TextPart(name, value, contentType));
+    }
+
+    /**
+     * Add a binary file part to the multipart form.
+     */
+    public void addFilePart(String name, String filename, InputStream data) {
+        this.filePart = new FilePart(name, filename, data);
+    }
+
+    /**
+     * Returns the Content-Type header value for this multipart body.
+     */
+    public String getContentType() {
+        return "multipart/form-data; boundary=" + boundary;
+    }
+
+    /**
+     * Builds an {@link HttpRequest.BodyPublisher} for this multipart form.
+     */
+    public HttpRequest.BodyPublisher toBodyPublisher() throws IOException {
+        if (filePart != null) {
+            return buildWithFilePart();
+        }
+        return buildTextOnly();
+    }
+
+    private HttpRequest.BodyPublisher buildTextOnly() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (TextPart part : textParts) {
+            writeBoundary(out);
+            writeTextPart(out, part);
+        }
+        writeClosingBoundary(out);
+        return HttpRequest.BodyPublishers.ofByteArray(out.toByteArray());
+    }
+
+    private HttpRequest.BodyPublisher buildWithFilePart() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (TextPart part : textParts) {
+            writeBoundary(out);
+            writeTextPart(out, part);
+        }
+        writeBoundary(out);
+        writeFilePartHeader(out, filePart);
+        byte[] preamble = out.toByteArray();
+
+        byte[] fileData = filePart.data.readAllBytes();
+        byte[] closing = (CRLF + TWO_HYPHENS + boundary + TWO_HYPHENS + CRLF).getBytes(StandardCharsets.UTF_8);
+
+        ByteArrayOutputStream all = new ByteArrayOutputStream();
+        all.write(preamble);
+        all.write(fileData);
+        all.write(closing);
+        return HttpRequest.BodyPublishers.ofByteArray(all.toByteArray());
+    }
+
+    private void writeBoundary(ByteArrayOutputStream out) {
+        try {
+            out.write((TWO_HYPHENS + boundary + CRLF).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeClosingBoundary(ByteArrayOutputStream out) {
+        try {
+            out.write((TWO_HYPHENS + boundary + TWO_HYPHENS + CRLF).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeTextPart(ByteArrayOutputStream out, TextPart part) {
+        try {
+            out.write(("Content-Disposition: form-data; name=\"" + part.name + "\"" + CRLF).getBytes(StandardCharsets.UTF_8));
+            out.write(("Content-Type: " + part.contentType + CRLF).getBytes(StandardCharsets.UTF_8));
+            out.write(CRLF.getBytes(StandardCharsets.UTF_8));
+            out.write(part.value.getBytes(StandardCharsets.UTF_8));
+            out.write(CRLF.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeFilePartHeader(ByteArrayOutputStream out, FilePart part) {
+        try {
+            out.write(("Content-Disposition: form-data; name=\"" + part.name
+                + "\"; filename=\"" + part.filename + "\"" + CRLF).getBytes(StandardCharsets.UTF_8));
+            out.write(("Content-Type: application/octet-stream" + CRLF).getBytes(StandardCharsets.UTF_8));
+            out.write(CRLF.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private record TextPart(String name, String value, String contentType) {}
+    private record FilePart(String name, String filename, InputStream data) {}
+}

--- a/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishManagedContainerConfiguration.java
+++ b/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishManagedContainerConfiguration.java
@@ -16,13 +16,14 @@
  */
 package org.jboss.arquillian.container.glassfish.managed;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
 import org.jboss.arquillian.container.glassfish.CommonGlassFishConfiguration;
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClient;
 import org.jboss.arquillian.container.spi.ConfigurationException;
-import org.jboss.arquillian.container.spi.client.deployment.Validate;
-
-import java.io.File;
-import java.nio.file.Path;
 
 /**
  * Configuration for Managed GlassFish containers.
@@ -132,10 +133,12 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
      * properties are set and have correct values
      */
     public void validate() throws ConfigurationException {
-        Validate.notNull(getGlassFishHome(),
+        Objects.requireNonNull(getGlassFishHome(),
             "The property glassFishHome must be specified or the GLASSFISH_HOME environment variable must be set");
-        Validate.configurationDirectoryExists(getGlassFishHome() + "/glassfish",
-            getGlassFishHome() + " is not a valid GlassFish installation");
+        if (!Files.isDirectory(Path.of(getGlassFishHome(), "glassfish"))) {
+            throw new IllegalArgumentException(
+                getGlassFishHome() + " is not a valid GlassFish installation");
+        }
 
         if (!getAdminCli().isFile()) {
             throw new IllegalArgumentException(
@@ -143,8 +146,9 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
         }
 
         if (getDomain() != null) {
-            Validate.configurationDirectoryExists(getGlassFishHome() + "/glassfish/domains/" + getDomain(),
-                "Invalid domain: " + getDomain());
+            if (!Files.isDirectory(Path.of(getGlassFishHome(), "glassfish", "domains", getDomain()))) {
+                throw new IllegalArgumentException("Invalid domain: " + getDomain());
+            }
         }
 
         super.validate();

--- a/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishManagedDeployableContainer.java
+++ b/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishManagedDeployableContainer.java
@@ -64,12 +64,13 @@ public class GlassFishManagedDeployableContainer implements DeployableContainer<
                 glassFishManager.start();
                 return;
             } else {
-                throw new LifecycleException("The server is already running! "
-                    + "Managed containers does not support connecting to running server instances due to the "
-                    + "possible harmful effect of connecting to the wrong server. Please stop server before running or "
-                    + "change to another type of container.\n"
-                    + "To disable this check and allow Arquillian to connect to a running server, "
-                    + "set allowConnectingToRunningServer to true in the container configuration");
+                throw new LifecycleException("""
+                    The server is already running! \
+                    Managed containers does not support connecting to running server instances due to the \
+                    possible harmful effect of connecting to the wrong server. Please stop server before running or \
+                    change to another type of container.
+                    To disable this check and allow Arquillian to connect to a running server, \
+                    set allowConnectingToRunningServer to true in the container configuration""");
             }
         } else {
             serverControl.start();

--- a/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishServerControl.java
+++ b/glassfish-managed/src/main/java/org/jboss/arquillian/container/glassfish/managed/GlassFishServerControl.java
@@ -24,7 +24,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,18 +37,15 @@ import static java.lang.Runtime.getRuntime;
  */
 class GlassFishServerControl {
 
-    private static final String DERBY_MISCONFIGURED_HINT =
-        "It seems that the Glassfish version you are running might have a problem starting embedded "
-            +
-            "Derby database. Please take a look at the server logs. You can also switch off 'enableDerby' property in your 'arquillian.xml' if you don't need it. For "
-            +
-            "more information please refer to relevant issues for existing workarounds: https://java.net/jira/browse/GLASSFISH-21004 "
-            +
-            "https://issues.apache.org/jira/browse/DERBY-6438";
+    private static final String DERBY_MISCONFIGURED_HINT = """
+        It seems that the Glassfish version you are running might have a problem starting embedded \
+        Derby database. Please take a look at the server logs. You can also switch off 'enableDerby' property in your 'arquillian.xml' if you don't need it. For \
+        more information please refer to relevant issues for existing workarounds: https://java.net/jira/browse/GLASSFISH-21004 \
+        https://issues.apache.org/jira/browse/DERBY-6438""";
 
 
     // see: https://github.com/eclipse-ee4j/glassfish/issues/25729
-    private static final List<String> NO_ARGS = Collections.emptyList();
+    private static final List<String> NO_ARGS = List.of();
 
     private static final Logger logger = Logger.getLogger(GlassFishServerControl.class.getName());
 
@@ -99,7 +95,7 @@ class GlassFishServerControl {
             return;
         }
         try {
-            executeAdminCommand("Starting database", "start-database", Collections.emptyList(), NO_ARGS, createProcessOutputConsumer());
+            executeAdminCommand("Starting database", "start-database", List.of(), NO_ARGS, createProcessOutputConsumer());
         } catch (LifecycleException e) {
             logger.warning(DERBY_MISCONFIGURED_HINT);
             throw e;
@@ -108,7 +104,7 @@ class GlassFishServerControl {
 
     private void stopDerbyDatabase() throws LifecycleException {
         if (config.isEnableDerby()) {
-            executeAdminCommand("Stopping database", "stop-database", Collections.emptyList(),  NO_ARGS, createProcessOutputConsumer());
+            executeAdminCommand("Stopping database", "stop-database", List.of(),  NO_ARGS, createProcessOutputConsumer());
         }
     }
 
@@ -120,15 +116,13 @@ class GlassFishServerControl {
     }
 
     private void registerShutdownHook() {
-        shutdownHook = new Thread(new Runnable() {
-            public void run() {
-                logger.warning("Forcing container shutdown");
-                try {
-                    stopContainer();
-                    stopDerbyDatabase();
-                } catch (LifecycleException e) {
-                    logger.log(Level.SEVERE, "Failed stopping services through shutdown hook.", e);
-                }
+        shutdownHook = new Thread(() -> {
+            logger.warning("Forcing container shutdown");
+            try {
+                stopContainer();
+                stopDerbyDatabase();
+            } catch (LifecycleException e) {
+                logger.log(Level.SEVERE, "Failed stopping services through shutdown hook.", e);
             }
         });
         getRuntime().addShutdownHook(shutdownHook);
@@ -140,7 +134,7 @@ class GlassFishServerControl {
             args.add(config.getDomain());
         }
 
-        executeAdminCommand(description, adminCmd, Collections.emptyList(), args, consumer);
+        executeAdminCommand(description, adminCmd, List.of(), args, consumer);
     }
 
     private void executeAdminCommand(String description, String command,  List<String> asadminArgs, List<String> args,

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- maven plugins -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
 
     <!-- Glassfish -->
     <glassfish.version>7.0.13</glassfish.version>
-    <jersey.version>3.1.10</jersey.version>
 
     <!-- Jakarta EE API 10.0.0 -->
     <jakartaee-bom.version>10.0.0</jakartaee-bom.version>
@@ -87,14 +86,6 @@
         <scope>import</scope>
       </dependency>
 
-      <!-- JAX-RS implementation -->
-      <dependency>
-        <groupId>org.glassfish.jersey</groupId>
-        <artifactId>jersey-bom</artifactId>
-        <version>${jersey.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
 
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
@
## Summary

Replace all Jersey REST Client / Jakarta REST Client code in glassfish-common with Java 11 built-in java.net.http.HttpClient, eliminating 3 Jersey dependencies.

## Changes

### New file
- **MultipartBody.java** — lightweight multipart/form-data body builder for java.net.http.HttpClient

### Rewritten
- **GlassFishClientUtil.java** — Jersey to java.net.http.HttpClient
  - Basic auth via java.net.Authenticator
  - CSRF header (X-Requested-By) added manually
  - Debug logging prints request/response directly (was Jersey LoggingFeature)
  - GETRequest() now supports path template resolution + query params
  - POSTMultiPartRequest() uses MultipartBody instead of FormDataMultiPart

### Updated API
- **GlassFishClient.java** — FormDataMultiPart to MultipartBody in doDeploy/doUndeploy
- **GlassFishClientService.java** — WebTarget/Response chains to new GETRequest(path, templates, params)
- **CommonGlassFishManager.java** — FormDataMultiPart/StreamDataBodyPart to MultipartBody

### Dependencies removed
- org.glassfish.jersey.core:jersey-client
- org.glassfish.jersey.inject:jersey-hk2
- org.glassfish.jersey.media:jersey-media-multipart
- Jersey BOM from root pom.xml

## Verification
- ./mvnw -B compile -DskipTests — BUILD SUCCESS (all 5 modules)
- 8 source files compiled, zero Jersey imports remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@