### PR TITLE
fix: force HTTP/1.1 on HttpClient to prevent EOF errors with GlassFish admin API

### DIFF
--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/client/GlassFishRestClient.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/client/GlassFishRestClient.java
@@ -31,6 +31,9 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -47,6 +50,30 @@ public class GlassFishRestClient {
     private static final String CSRF_HEADER = "X-Requested-By";
     private static final String CSRF_VALUE = "GlassFish REST Client";
 
+    /**
+     * Shared executor for all {@link GlassFishRestClient} instances.
+     * Uses daemon threads so pending async tasks do not block JVM shutdown,
+     * and a fixed pool to bound resource usage — the admin REST API call volume
+     * is low (occasional deploy/undeploy/config queries), not a high-throughput
+     * service.
+     */
+    private static final int HTTP_EXECUTOR_POOL_SIZE =
+        Math.clamp(Runtime.getRuntime().availableProcessors(), 2, 8);
+
+    private static final ExecutorService HTTP_EXECUTOR =
+        Executors.newFixedThreadPool(HTTP_EXECUTOR_POOL_SIZE, new GlassFishClientThreadFactory());
+
+    private static class GlassFishClientThreadFactory implements ThreadFactory {
+        private int counter;
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "glassfish-rest-client-" + (++counter));
+            t.setDaemon(true);
+            return t;
+        }
+    }
+
     private final String adminBaseUrl;
     private final boolean debugRequests;
     private final HttpClient httpClient;
@@ -56,6 +83,8 @@ public class GlassFishRestClient {
         this.adminBaseUrl = adminBaseUrl;
         this.debugRequests = debugRequests;
         HttpClient.Builder builder = HttpClient.newBuilder()
+            .executor(HTTP_EXECUTOR)
+            .version(HttpClient.Version.HTTP_1_1)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .connectTimeout(Duration.ofSeconds(30));
         if (adminUser != null) {
@@ -265,6 +294,7 @@ public class GlassFishRestClient {
 
     private HttpRequest.Builder newGetBuilder() {
         return HttpRequest.newBuilder()
+            .timeout(Duration.ofSeconds(30))
             .header("Accept", "application/xml")
             .header(CSRF_HEADER, CSRF_VALUE)
             .header(USER_AGENT_HEADER, USER_AGENT_VALUE);
@@ -272,6 +302,7 @@ public class GlassFishRestClient {
 
     private HttpRequest.Builder newPostBuilder() {
         return HttpRequest.newBuilder()
+            .timeout(Duration.ofSeconds(30))
             .header("Accept", "application/xml")
             .header(CSRF_HEADER, CSRF_VALUE)
             .header(USER_AGENT_HEADER, USER_AGENT_VALUE);


### PR DESCRIPTION
## Problem

The `Build/integration-tests` CI workflow fails intermittently with:

```
GlassFishRestClientIT.shouldGetProtocolAttributes:87 » GlassFishClient java.io.IOException: EOF reached while reading
```

Root cause: `java.io.EOFException: EOF reached while reading` at `Http2Connection$Http2TubeSubscriber.onComplete`

## Root Cause

GlassFish 7.x's Grizzly admin listener (port 4848) has HTTP/2 enabled by default
(`http2-enabled` defaults to `true`), and the JDK `HttpClient` negotiates it
successfully via ALPN — which is why most tests pass. However, the JDK's HTTP/2
implementation has a [known bug (JDK-8236596)](https://github.com/openjdk/jdk11u-dev/pull/608)
where HTTP/2 connections are improperly shut down (the source literally throws
`new EOFException("HTTP/2 client stopped")`), leaving sockets in `CLOSE_WAIT`.
Combined with [Grizzly's connection-close quirks](https://github.com/eclipse-ee4j/glassfish-grizzly/issues/1939),
a connection that works for several requests is later silently killed, causing the
next in-flight request to fail with EOF.

This is random because:
- Whether HTTP/2 or HTTP/1.1 is negotiated depends on ALPN timing
- If HTTP/2, the shared connection survives N requests then the JDK bug triggers
- Test ordering determines which test catches the EOF

## Fix

1. **Force HTTP/1.1** (`.version(HttpClient.Version.HTTP_1_1)`): avoids the
   JDK HTTP/2 connection-management bugs. This admin REST API was designed as
   HTTP/1.1 and gains nothing from multiplexing — each call is a simple request/response.

2. **Shared daemon ExecutorService** (`.executor(HTTP_EXECUTOR)`): replaces the
   default per-instance cached thread pool (non-daemon threads that block JVM
   shutdown). Pool size is `clamp(availableProcessors(), 2, 8)`.

3. **Per-request timeout** (`.timeout(30s)`): safety net against hangs.

## Evidence

`domain.xml` confirms HTTP/2 is active on the admin listener:
```xml
<protocol name="admin-listener">
    <http max-connections="250" default-virtual-server="__asadmin">
        <file-cache/>
    </http>
</protocol>
```
No `http2-enabled="false"` → defaults to `true` in GF 7.1.

## Testing

- Unit tests: all 12 pass (`mvn test -pl glassfish-common`)
- Integration tests should now pass reliably against the GF7 Cargo-managed container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
