### PR TITLE
Clean up integration-tests Arquillian config

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,3 +104,23 @@ jobs:
         with:
           name: server-log-gf8-remote
           path: integration-tests/target/cargo/configurations/glassfish8x/cargo-domain/logs/server.log
+
+  gf8-managed-derby:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: "temurin"
+          cache: "maven"
+      - name: Run GF 8 Managed Tests with Derby
+        run: ./mvnw -B verify -pl integration-tests -am -Pmanaged,enableDerby,v8 --file pom.xml
+      - name: Upload GF8 Managed Derby server.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-log-gf8-managed-derby
+          path: integration-tests/target/glassfish8/glassfish/domains/domain1/logs/server.log

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -140,7 +140,6 @@
             <configuration>
               <systemPropertyVariables>
                 <glassfish.home>${glassfish.home}</glassfish.home>
-                <enableDerby>false</enableDerby>
                 <arquillian.launch>glassfish-managed</arquillian.launch>
               </systemPropertyVariables>
             </configuration>
@@ -231,6 +230,27 @@
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <cargo.container.id>glassfish8x</cargo.container.id>
       </properties>
+    </profile>
+
+    <!-- Enable Derby database for managed container tests -->
+    <profile>
+      <id>enableDerby</id>
+      <properties>
+        <glassfish.enableDerby>true</glassfish.enableDerby>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <glassfish.enableDerby>${glassfish.enableDerby}</glassfish.enableDerby>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/integration-tests/src/test/java/org/jboss/arquillian/container/glassfish/test/GlassFishDeploymentTestTemplate.java
+++ b/integration-tests/src/test/java/org/jboss/arquillian/container/glassfish/test/GlassFishDeploymentTestTemplate.java
@@ -35,7 +35,7 @@ public abstract class GlassFishDeploymentTestTemplate {
     }
 
     public static Class<?> greeterImplementationBasedOnDerbyEnabled() {
-        if (Boolean.parseBoolean(System.getProperty("glassfish.enableDerby"))) {
+        if (Boolean.getBoolean("glassfish.enableDerby")) {
             return GreeterServletWithDerby.class;
         }
         return GreeterServlet.class;

--- a/integration-tests/src/test/java/org/jboss/arquillian/container/glassfish/test/GlassFishDeploymentTestTemplate.java
+++ b/integration-tests/src/test/java/org/jboss/arquillian/container/glassfish/test/GlassFishDeploymentTestTemplate.java
@@ -35,7 +35,7 @@ public abstract class GlassFishDeploymentTestTemplate {
     }
 
     public static Class<?> greeterImplementationBasedOnDerbyEnabled() {
-        if (Boolean.parseBoolean(System.getProperty("enableDerby"))) {
+        if (Boolean.parseBoolean(System.getProperty("glassfish.enableDerby"))) {
             return GreeterServletWithDerby.class;
         }
         return GreeterServlet.class;

--- a/integration-tests/src/test/resources/arq-glassfish-managed/arquillian.xml
+++ b/integration-tests/src/test/resources/arq-glassfish-managed/arquillian.xml
@@ -11,11 +11,14 @@
 
   <container qualifier="glassfish-managed" default="true">
     <configuration>
-      <property name="glassFishHome">${glassfish.home}</property>
+      <!-- glassFishHome is resolved from the GLASSFISH_HOME environment variable
+           or the `glassfish.home` system property. -->
+      <!-- <property name="glassFishHome">${glassfish.home}</property> -->
       <property name="adminHost">localhost</property>
       <property name="adminPort">4848</property>
       <property name="debug">true</property>
-      <property name="enableDerby">${enableDerby:true}</property>
+      <!-- enableDerby is resolved from the `glassfish.enableDerby` system property (default false). -->
+      <!-- <property name="enableDerby">${enableDerby:true}</property> -->
       <property name="allowConnectingToRunningServer">false</property>
       <property name="outputToConsole">true</property>
       <property name="debugRequests">true</property>

--- a/integration-tests/src/test/resources/arq-glassfish-remote/arquillian.xml
+++ b/integration-tests/src/test/resources/arq-glassfish-remote/arquillian.xml
@@ -11,10 +11,10 @@
 
   <container qualifier="glassfish-remote" default="true">
     <configuration>
-      <property name="adminHost">${glassfish.adminHost:localhost}</property>
-      <property name="adminPort">${glassfish.adminPort:4848}</property>
-      <property name="adminUser">${glassfish.adminUser:admin}</property>
-      <property name="adminPassword">${glassfish.adminPassword:adminadmin}</property>
+      <property name="adminHost">localhost</property>
+      <property name="adminPort">4848</property>
+      <property name="adminUser">admin</property>
+      <property name="adminPassword">adminadmin</property>
       <property name="debugRequests">true</property>
     </configuration>
   </container>


### PR DESCRIPTION
## Summary

Cleans up the redundant property wiring in the `integration-tests` module. The managed container (`ManagedContainerConfiguration`) already auto-resolves `glassFishHome` from `GLASSFISH_HOME` env / `glassfish.home` sysprop and `enableDerby` from `glassfish.enableDerby` sysprop, so the explicit `${...}` placeholders in `arquillian.xml` are redundant.

## Changes

- **managed `arquillian.xml`** — comment out `glassFishHome` and `enableDerby` properties with descriptions.
- **`integration-tests/pom.xml`** — remove `enableDerby` from the managed failsafe; add a self-contained `enableDerby` profile (property + failsafe `systemPropertyVariables`).
- **`GlassFishDeploymentTestTemplate`** — rename the Derby flag read from `enableDerby` to `glassfish.enableDerby`.
- **remote `arquillian.xml`** — hardcode the admin connection defaults (`localhost:4848`, `admin`/`adminadmin`).
- **CI** — add a `gf8-managed-derby` job running the `managed,enableDerby,v8` profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)